### PR TITLE
Feat impl

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 
 set -e 
 
-for i in {0..18}
+for i in {0..19}
 do
    node outs/index.js -c tests/test$i -o ./output  --generate-ir --run --no-warnings
 done

--- a/source/ast/expressions/MemberAccessExpression.ts
+++ b/source/ast/expressions/MemberAccessExpression.ts
@@ -445,11 +445,24 @@ export class MemberAccessExpression extends Expression {
         typeMap: { [key: string]: DataType },
         ctx: Context,
     ): MemberAccessExpression {
-        return new MemberAccessExpression(
+        let expr = new MemberAccessExpression(
             this.location,
             this.left.clone(typeMap, ctx),
             this.right.clone(typeMap, ctx),
             this.isNullable,
         );
+
+        if(this.left instanceof ThisExpression) {
+            /**
+             * While we do remove withinImplementation when we clone the context,
+             * the child context still has it set to true, so we check if we are within a class to
+             */
+            if(ctx.env.withinImplementation && !ctx.env.withinClass) {
+                let method = ctx.getActiveImplementationMethod()
+                method!.thisMemberAccessExpression.push(expr);
+            }
+        }
+
+        return expr;
     }
 }

--- a/source/ast/expressions/ThisExpression.ts
+++ b/source/ast/expressions/ThisExpression.ts
@@ -58,7 +58,7 @@ export class ThisExpression extends Expression {
             return this.inferredType;
         }
         else {
-            ctx.parser.customError(`'this' can only be used within a class or thread`, this.location);
+            ctx.parser.customError(`'this' can only be used within a class`, this.location);
         }
     }
 

--- a/source/ast/other/ImplementationAttribute.ts
+++ b/source/ast/other/ImplementationAttribute.ts
@@ -1,0 +1,27 @@
+/**
+ * Filename: ImplementationAttribute.ts
+ * Author: Soulaymen Chouri
+ * Date: 2023-2024
+ *
+ * Description:
+ *     Models an implementation attribute
+ *
+ * Type-C Compiler, Copyright (c) 2023-2024 Soulaymen Chouri. All rights reserved.
+ * This file is licensed under the terms described in the LICENSE.md.
+ */
+
+import { DataType } from "../types/DataType";
+import { SymbolLocation } from "../symbol/SymbolLocation";
+import { Symbol } from "../symbol/Symbol";
+import { ClassAttribute } from "./ClassAttribute";
+
+export class ImplementationAttribute extends ClassAttribute {
+
+    constructor(location: SymbolLocation, name: string, type: DataType, isStatic: boolean, isConst: boolean) {
+        super(location, name, type, isStatic, isConst);
+    }
+
+    clone(genericsTypeMap: { [key: string]: DataType }): ImplementationAttribute {
+        return super.clone(genericsTypeMap);
+    }
+}

--- a/source/ast/other/ImplementationMethod.ts
+++ b/source/ast/other/ImplementationMethod.ts
@@ -1,0 +1,170 @@
+/**
+ * Filename: ImplementationMethod.ts
+ * Author: Soulaymen Chouri
+ * Date: 2023-2024
+ * 
+ * Description:
+ *     A method is a method defined in an implementation
+ * 
+ * Type-C Compiler, Copyright (c) 2023-2024 Soulaymen Chouri. All rights reserved.
+ * This file is licensed under the terms described in the LICENSE.md.
+ */
+
+
+import { Expression } from "../expressions/Expression";
+import { BlockStatement } from "../statements/BlockStatement";
+import { SymbolLocation } from "../symbol/SymbolLocation";
+import { Context } from "../symbol/Context";
+import { InterfaceMethod } from "./InterfaceMethod";
+import { DataType } from "../types/DataType";
+import { ClassMethod } from "./ClassMethod";
+import { MemberAccessExpression } from "../expressions/MemberAccessExpression";
+import { ClassAttribute } from "./ClassAttribute";
+import { Symbol } from "../symbol/Symbol";
+import { ReturnStatement } from "../statements/ReturnStatement";
+import { FunctionCodegenProps } from "../../codegenerator/FunctionCodegenProps";
+
+
+export class ImplementationMethod extends Symbol {
+
+    // to replace with the actual RHS once the class implementation args are known
+    thisMemberAccessExpression: MemberAccessExpression[] = [];
+
+
+    // interface method
+    imethod: InterfaceMethod;
+
+    // if the method has an expression
+    expression: Expression | null = null;
+    // or a statement block
+    body: BlockStatement | null = null;
+
+    context: Context;
+
+    /**
+     * List of return statements in the method, used for type checking
+     */
+    returnStatements: {stmt: ReturnStatement, ctx: Context}[] = [];
+    
+    codeGenProps: FunctionCodegenProps
+
+    
+    constructor(location: SymbolLocation, context: Context, imethod: InterfaceMethod, body: BlockStatement | null, expression: Expression | null) {
+        super(location, "implementation_method", imethod.name);
+
+        this.imethod = imethod;
+        this.context = context;
+        this.body = body;
+        this.expression = expression;
+        this.codeGenProps = new FunctionCodegenProps(imethod.header);
+    }
+
+    shortname(): string {
+        return "impl{"+this.imethod.shortname()+"}";
+    }
+
+    serialize(unpack: boolean = false): string {
+        return `@impl{method{${this.imethod.serialize(unpack)}}}`
+    }
+
+    infer(ctx: Context) {
+        //super.infer(ctx);
+    }
+
+
+    cloneImpl(typeMap: { [key: string]: DataType; }, removeGenerics: boolean = false, newCtx: Context): ImplementationMethod {
+        let newProto = this.imethod.clone(typeMap);
+
+        if(removeGenerics === true) {
+            newProto.generics = [];
+        }
+
+        let fn = new ImplementationMethod(this.location, newCtx, newProto, null, null);
+        newCtx.setOwner(fn);
+
+        // we delay the cloning of the body and expression because
+        // return statements in body requires the owner in the 
+        // context to refer to the method, which is not set until after
+        // the fn has been constucted and then the body cloned
+        fn.expression = this.expression?.clone(typeMap, newCtx) || null;
+        fn.body = this.body?.clone(typeMap, newCtx) || null;
+
+        if(fn.body !== null) {
+            fn.body.context.overrideParent(fn.context);
+        }
+        return fn;
+    }
+
+
+    clone(typeMap: { [key: string]: DataType; }, removeGenerics: boolean = false): ImplementationMethod {
+        
+        let newCtx = this.context.clone(typeMap, this.context.getParent());
+        let newProto = this.imethod.clone(typeMap);
+
+        if(removeGenerics === true) {
+            newProto.generics = [];
+        }
+
+        let fn = new ImplementationMethod(this.location, newCtx, newProto, null, null);
+        // we delay the cloning of the body and expression because
+        // return statements in body requires the owner in the 
+        // context to refer to the method, which is not set until after
+        // the fn has been constucted and then the body cloned
+        fn.expression = this.expression?.clone(typeMap, newCtx) || null;
+        fn.body = this.body?.clone(typeMap, newCtx) || null;
+
+        if(fn.body !== null) {
+            fn.body.context.overrideParent(fn.context);
+        }
+        return fn;
+    }
+
+    toClassMethod(classAttrMap: { [key: string]: ClassAttribute }) {
+        // first clone the implementation method so we can safely override the member access expressions
+
+        let emptyMap: { [key: string]: DataType } = {};
+
+        // create method ctx and capture return statements
+        let newCtx = this.context.clone(emptyMap, this.context.getParent());
+        newCtx.env.withinImplementation = true;
+        newCtx.env.withinFunction = true;
+
+        let newMethod = this.cloneImpl(emptyMap, false, newCtx);
+
+        // now we replace the this expression with the class attribute
+        for (const expr of newMethod.thisMemberAccessExpression) {
+            let attr = classAttrMap[expr.right.name];
+            if(attr === undefined) {
+                // could be a method call, we resume
+                continue;
+            }
+
+            
+
+            // replace the RHS with the attribute name
+            expr.right.name = attr.name;
+        }
+
+
+
+        newCtx.env.withinImplementation = false;
+        newCtx.env.withinFunction = true;
+        newCtx.env.withinClass = true;
+        newCtx.removeImplementationEnv();
+        let fn = new ClassMethod(this.location, newCtx, newMethod.imethod.clone(emptyMap), null, null);
+        // we delay the cloning of the body and expression because
+        // return statements in body requires the owner in the 
+        // context to refer to the method, which is not set until after
+        // the fn has been constucted and then the body cloned
+        fn.expression = newMethod.expression;
+        fn.body = newMethod.body;
+        fn.returnStatements = newMethod.returnStatements;
+
+        if(fn.body !== null) {
+            fn.body.context.overrideParent(fn.context);
+        }
+        newCtx.setOwner(fn);
+        return fn;
+    }
+
+}

--- a/source/ast/statements/ReturnStatement.ts
+++ b/source/ast/statements/ReturnStatement.ts
@@ -57,7 +57,8 @@ export class ReturnStatement extends Statement {
     clone(typeMap: {[key: string]: DataType}, ctx: Context): ReturnStatement {
         let newExpression = this.returnExpression ? this.returnExpression.clone(typeMap, ctx) : null;
         let newReturn = new ReturnStatement(this.location, newExpression);
-        ctx.findParentFunction()?.returnStatements.push({ctx: ctx, stmt: newReturn});
+        let p = ctx.findParentFunction()
+        p?.returnStatements.push({ctx: ctx, stmt: newReturn});
         return newReturn;
     }
 }

--- a/source/ast/symbol/Symbol.ts
+++ b/source/ast/symbol/Symbol.ts
@@ -20,7 +20,9 @@ export type SymbolKind =
     "function_argument" |
     "closure_argument" |
     "class_attribute" |
+    "implementation_attribute" |
     "class_method" |
+    "implementation_method" |
     "function" |
     "lambda" |
     "ffi" |

--- a/source/ast/types/ArrayType.ts
+++ b/source/ast/types/ArrayType.ts
@@ -14,6 +14,7 @@ import {DataType} from "./DataType";
 import {SymbolLocation} from "../symbol/SymbolLocation";
 import { Context } from "../symbol/Context";
 import { GenericType } from "./GenericType";
+import { ImplementationType } from "./ImplementationType";
 
 export class ArrayType extends DataType {
     arrayOf: DataType;
@@ -31,6 +32,11 @@ export class ArrayType extends DataType {
         }
 
         this.arrayOf.resolve(ctx);
+
+
+        if(this.arrayOf.is(ctx, ImplementationType)) {
+            ctx.parser.customError("Cannot have an array of implementation types", this.location);
+        }
 
         this.postResolveRecursion();
     }

--- a/source/ast/types/DataType.ts
+++ b/source/ast/types/DataType.ts
@@ -58,8 +58,8 @@ export type DataTypeKind =
     "meta_enum" | // MetaStructType, used for meta structs
     "tuple" | // TupleType
     "coroutine"| // CoroutineType, representing a coroutine instance
-    "cofn"; // CoFunctionType, representing a coroutine function
-
+    "cofn" | // CoFunctionType, representing a coroutine function
+    "implementation"; // ImplementationType, representing an implementation
 
 export class DataType {
     kind: DataTypeKind;

--- a/source/ast/types/ImplementationType.ts
+++ b/source/ast/types/ImplementationType.ts
@@ -1,0 +1,98 @@
+/**
+ * Filename: ImplementationType.ts
+ * Author: Soulaymen Chouri
+ * Date: 2023-2024
+ * 
+ * Description:
+ *     Models an implementation type in the type-c language. Implementation is a set of methods that can be 
+ *     reused by classes. They can have requirements (attributes) and methods (interfaces)
+ * 
+ * Copyright (c) 2023-2024 Soulaymen Chouri. All rights reserved.
+ * This file is licensed under the terms described in the LICENSE.md.
+ */
+
+
+import { ClassMethod } from "../other/ClassMethod";
+import { ImplementationAttribute } from "../other/ImplementationAttribute";
+import { ImplementationMethod } from "../other/ImplementationMethod";
+import { Context } from "../symbol/Context";
+import { SymbolLocation } from "../symbol/SymbolLocation";
+import { DataType } from "./DataType";
+import { GenericType } from "./GenericType";
+import { InterfaceType } from "./InterfaceType";
+
+
+export class ImplementationType extends DataType {
+    requiredAttributes: ImplementationAttribute[] = [];
+    requiredInterface: DataType | null = null; // could be a join
+
+    implementedMethods: ImplementationMethod[] = [];
+    
+
+    constructor(location: SymbolLocation, requiredAttributes: ImplementationAttribute[], requiredInterface: DataType | null = null, implementedMethods: ImplementationMethod[] = []) {
+        super(location, "implementation");
+        this.requiredAttributes = requiredAttributes;
+        this.requiredInterface = requiredInterface;
+        this.implementedMethods = implementedMethods;
+    }
+
+    resolve(ctx: Context) {
+        if(this.requiredInterface) {
+            // we make sure that the interface is resolved
+            this.requiredInterface.resolve(ctx);
+            if(!this.requiredInterface.is(ctx, InterfaceType)) {
+                ctx.parser.customError(`Required interface ${this.requiredInterface.shortname()} is not an interface`, this.location);
+            }
+        }
+
+        this.checkAttributes(ctx);
+        this.checkNoInitMethods(ctx);
+
+        // we do not go deeper than this, further inference is done in the class type
+    }
+
+
+    /**
+     * Copy pasta from ClassType.ts
+     * Check attributes, rules:
+     * 1. Static attributes cannot be generic
+     * 2. Must be called `init`.
+     */
+    checkAttributes(ctx: Context) {
+        for (const attribute of this.requiredAttributes) {
+            if (attribute.name === "init") {
+                ctx.parser.customError("Class attributes cannot be called `init`", attribute.location);
+            }
+
+            attribute.type.resolve(ctx);
+        }
+    }
+
+    checkNoInitMethods(ctx: Context) {
+        for(let method of this.implementedMethods) {
+            if(method.imethod.name === "init") {
+                ctx.parser.customError("Implementation methods cannot be called `init`", method.location);
+            }
+        }
+    }
+
+    shortname(): string {
+        return `implementation ${this.requiredInterface?("for " + this.requiredInterface.shortname()):""}(${this.requiredAttributes.map(a => a.name).join(", ")}){${this.implementedMethods.map(m => m.shortname()).join(", ")}}`
+    }
+
+    serialize(unpack: boolean = false): string {
+        return `@impl{for{${this.requiredInterface?.serialize(unpack)}}, attrs{${this.requiredAttributes.map(a => a.serialize(unpack)).join(", ")}}, methods{${this.implementedMethods.map(m => m.serialize(unpack)).join(", ")}}}`
+    }
+
+    isAssignable(): boolean {
+        return false;
+    }
+
+    clone(genericsTypeMap: { [key: string]: DataType }): ImplementationType {
+        return new ImplementationType(this.location, this.requiredAttributes.map(a => a.clone(genericsTypeMap)), this.requiredInterface?.clone(genericsTypeMap) || null, this.implementedMethods.map(m => m.clone(genericsTypeMap)));
+    }
+
+    getGenericParametersRecursive(ctx: Context, originalType: DataType, declaredGenerics: {[key: string]: GenericType}, typeMap: {[key: string]: DataType}) {
+        throw new Error("Unreachable");
+    }
+}

--- a/source/ast/types/NullableType.ts
+++ b/source/ast/types/NullableType.ts
@@ -14,6 +14,7 @@ import { Context } from "../symbol/Context";
 import {SymbolLocation} from "../symbol/SymbolLocation";
 import {DataType} from "./DataType";
 import { GenericType } from "./GenericType";
+import { ImplementationType } from "./ImplementationType";
 import { NullType } from "./NullType";
 import { TupleType } from "./TupleType";
 
@@ -42,6 +43,9 @@ export class NullableType extends DataType {
         }
         if (this.type.is(ctx, TupleType)){
             ctx.parser.customError("Tuples cannot be nullable", this.type.location);
+        }
+        if(this.type.is(ctx, ImplementationType)) {
+            ctx.parser.customError("Cannot have a nullable implementation type", this.type.location);
         }
 
         this.type.resolve(ctx);

--- a/source/codegenerator/BytecodeGenerator.ts
+++ b/source/codegenerator/BytecodeGenerator.ts
@@ -1244,7 +1244,7 @@ export class BytecodeGenerator {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
                 let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                this.emit(BytecodeInstructionType.sub_u32, dest, src1, src2);
+                this.emit(BytecodeInstructionType.sub_f32, dest, src1, src2);
             }
             else if (instruction.type == "sub_i64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
@@ -1455,44 +1455,44 @@ export class BytecodeGenerator {
             }
             else if (instruction.type == "lshift_i16") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.lshift_i16, dest, src1, src2);
             }
             else if (instruction.type == "lshift_i32") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.lshift_i32, dest, src1, src2);
             }
             else if (instruction.type == "lshift_i64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.lshift_i64, dest, src1, src2);
             }
             else if (instruction.type == "rshift_i8") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.rshift_i8, dest, src1, src2);
             }
             else if (instruction.type == "rshift_i16") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.rshift_i16, dest, src1, src2);
             }
             else if (instruction.type == "rshift_i32") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.rshift_i32, dest, src1, src2);
             }
             else if (instruction.type == "rshift_i64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[3] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.rshift_i64, dest, src1, src2);
             }
 
@@ -1504,72 +1504,72 @@ export class BytecodeGenerator {
             else if (instruction.type == "band_i8" || instruction.type == "band_u8") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
                 let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
-                let src2 = this.getRegisterForVariable(fn, instruction.args[1] as string);
+                let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.band_8, dest, src1, src2);
             }
             else if (instruction.type == "band_i16" || instruction.type == "band_u16") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.band_16, dest, src1, src2);
             }
             else if (instruction.type == "band_i32" || instruction.type == "band_u32") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.band_32, dest, src1, src2);
             }
             else if (instruction.type == "band_i64" || instruction.type == "band_u64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.band_64, dest, src1, src2);
             }
             else if (instruction.type == "bor_i8" || instruction.type == "bor_u8") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bor_8, dest, src1, src2);
             }
             else if (instruction.type == "bor_i16" || instruction.type == "bor_u16") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bor_16, dest, src1, src2);
             }
             else if (instruction.type == "bor_i32" || instruction.type == "bor_u32") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bor_32, dest, src1, src2);
             }
             else if (instruction.type == "bor_i64" || instruction.type == "bor_u64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bor_64, dest, src1, src2);
             }
             else if (instruction.type == "bxor_i8" || instruction.type == "bxor_u8") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bxor_8, dest, src1, src2);
             }
             else if (instruction.type == "bxor_i16" || instruction.type == "bxor_u16") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bxor_16, dest, src1, src2);
             }
             else if (instruction.type == "bxor_i32" || instruction.type == "bxor_u32") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bxor_32, dest, src1, src2);
             }
             else if (instruction.type == "bxor_i64" || instruction.type == "bxor_u64") {
                 let dest = this.getRegisterForVariable(fn, instruction.args[0] as string);
-                let src1 = this.getRegisterForVariable(fn, instruction.args[2] as string);
+                let src1 = this.getRegisterForVariable(fn, instruction.args[1] as string);
                 let src2 = this.getRegisterForVariable(fn, instruction.args[2] as string);
                 this.emit(BytecodeInstructionType.bxor_64, dest, src1, src2);
             }

--- a/source/codegenerator/FunctionGenerator.ts
+++ b/source/codegenerator/FunctionGenerator.ts
@@ -2844,7 +2844,8 @@ export class FunctionGenerator {
                 "debug",
                 "unary minus expression, replacing with subtraction with 0",
             );
-            this.i(constType(lhsType), zeroTmp, 0);
+            // must set entire register
+            this.i("const_u64", zeroTmp, 0);
             this.i(
                 getUnaryInstruction(expr.inferredType as BasicType, "-"),
                 resTmp,

--- a/source/lexer/Lexer.ts
+++ b/source/lexer/Lexer.ts
@@ -46,6 +46,7 @@ export class Lexer {
         [TokenType.TOK_FN, /^fn\b/],
         [TokenType.TOK_IF, /^if\b/],
         [TokenType.TOK_IMPORT, /^import\b/],
+        [TokenType.TOK_IMPL, /^impl\b/],
         [TokenType.TOK_IN, /^in\b/],
         [TokenType.TOK_IS, /^is\b/],
         [TokenType.TOK_INTERFACE, /^interface\b/],

--- a/source/lexer/TokenType.ts
+++ b/source/lexer/TokenType.ts
@@ -33,6 +33,7 @@ export enum TokenType {
     TOK_CFN = "cfn",
     TOK_IF = "if",
     TOK_IMPORT = "import",
+    TOK_IMPL = "impl",
     TOK_IN = "in",
     TOK_IS = "is",
     TOK_INTERFACE = "interface",

--- a/tests/test19/module.json
+++ b/tests/test19/module.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "author": "praisethemoon",
     "dependencies": [],
-    "description": "Tests Nullish coalescing operator",
+    "description": "Tests Implementation Type",
     "compiler": {
         "target": "runnable",
         "entry": "test.tc"

--- a/tests/test19/test.tc
+++ b/tests/test19/test.tc
@@ -1,34 +1,237 @@
-
-
-from std.string import String
-/*
 from std.io import println
 from std.unit.test import TestUnit, UnitSet
-*/
 
-type RandomAssType = class {
-    let static x: u32
-    let static y: u32
+type Callable<T> = interface {
+    fn __call__() -> T
+}
 
-    fn __init__(){
-
+type DefaultCallBehavior<T> = impl(
+    value: T
+) {
+    fn __call__() -> T {
+        return this.value
     }
 }
 
-type CustomStruct = {name: String, age: u32, data: struct {
-    x: u32, y: u32
-}?}
+type Placeholder<T> = class {
+    let v: T  
+    
+    fn init(mut v: T) {
+        this.v = v
+    }
 
-fn callMe<T>(x: T) {
-    return 1 as T
+    impl DefaultCallBehavior<T>(v)
 }
 
-let zzz = callMe(1 as u32)
+fn test_callable_placeholder(rn: TestUnit) {
+    let p = new Placeholder<u32>(42)
+    let v = p()
+    rn.assert_eq(v, 42)
 
-let z : CustomStruct? = {name: "Brian", age: 13, data: null}
+    let p2 = new Placeholder<String>("Haha")
+    let v2 = p2()
+    rn.assert_obj_eq(v2, "Haha")
+}
 
-let a: u32 = z?.age ?? 0
+type Vec3 = class {
+    let x: f32
+    let y: f32
+    let z: f32
 
-let b = z?.age ?? z?.age ?? 0
+    fn init(x: f32, y: f32, z: f32) {
+        this.x = x
+        this.y = y
+        this.z = z
+    }
 
-let d = z?.name
+    fn __add__ (v: Vec3) -> Vec3 {
+        return new Vec3(this.x + v.x, this.y + v.y, this.z + v.z)
+    }
+
+    fn __mul__ (v: Vec3) -> Vec3 {
+        return new Vec3(this.x * v.x, this.y * v.y, this.z * v.z)
+    }
+    
+    fn eq(v: Vec3) -> bool {
+        return (this.x == v.x) && (this.y == v.y) && (this.z == v.z)
+    }
+
+    fn toString() -> String {
+        return "Vec3(" + this.x + ", " + this.y + ", " + this.z + ")"
+    }
+}
+
+type Object3D = interface {
+    fn getRotation() -> Vec3
+    fn setRotation(mut rot: Vec3) -> void
+    fn getPosition() -> Vec3
+    fn setPosition(pos: Vec3) -> void
+    fn getScale() -> Vec3
+    fn setScale(scale: Vec3) -> void
+
+    fn getWorldPosition() -> Vec3
+    fn getWorldRotation() -> Vec3
+    fn getWorldScale() -> Vec3
+}
+
+namespace traits {
+    type Default3DPropsAccessTrait = impl (
+        pos: Vec3,
+        rot: Vec3,
+        slx: Vec3
+    ) {
+        fn getRotation() -> Vec3 = this.rot
+        fn getPosition() -> Vec3 = this.pos
+        fn getScale() -> Vec3 = this.slx
+
+        fn setRotation(mut rot: Vec3) -> void {
+            this.rot = rot
+        }
+
+        fn setPosition(mut pos: Vec3) -> void {
+            this.pos = pos
+        }
+
+        fn setScale(mut scale: Vec3) -> void {
+            this.slx = scale
+        }
+    }
+
+    type DefaultWorldTrait = impl for interface {
+        fn getPosition() -> Vec3
+        fn getRotation() -> Vec3
+        fn getScale() -> Vec3
+    } (
+        parent: Object3D?
+    ) {
+        fn getWorldPosition() -> Vec3 {
+            if(this.parent == null){
+                return this.getPosition()
+            }
+            return this.getPosition() + this.parent!.getWorldPosition()
+        }
+
+        fn getWorldRotation() -> Vec3 {
+            if(this.parent == null){
+                return this.getRotation()
+            }
+            return this.getRotation() + this.parent!.getWorldRotation()
+        }
+
+        fn getWorldScale() -> Vec3 {
+            if(this.parent == null){
+                return this.getScale()
+            }
+            return this.getScale() * this.parent!.getWorldScale()
+        }
+    }
+}
+
+type StaticMesh = class {
+    let position: Vec3
+    let rotation: Vec3
+    let scale: Vec3
+    let obj_parent: Object3D?
+
+    impl traits.Default3DPropsAccessTrait(position, rotation, scale)
+    impl traits.DefaultWorldTrait(obj_parent)
+
+    fn init(mut position: Vec3, mut rotation: Vec3, mut scale: Vec3) {
+        this.position = position
+        this.rotation = rotation
+        this.scale = scale
+        this.obj_parent = null
+    }
+}
+
+type DefaultGenericImpl<T> = impl (
+        value: T
+    ) {
+        fn getValue() -> T {
+            return this.value
+        }
+
+        fn setValue(mut newValue: T) -> void {
+            this.value = newValue
+        }
+    }
+
+type GenericContainer<T> = class {
+    let value: T
+
+    impl DefaultGenericImpl<T>(value)
+
+    fn init(mut value: T) {
+        this.value = value
+    }
+}
+
+fn test_generic_container(rn: TestUnit) {
+    let container = new GenericContainer<u32>(100)
+    rn.assert_eq(container.getValue(), 100)
+
+    container.setValue(200)
+    rn.assert_eq(container.getValue(), 200)
+
+    let strContainer = new GenericContainer<String>("Hello")
+    rn.assert_obj_eq(strContainer.getValue(), "Hello")
+
+    strContainer.setValue("World")
+    rn.assert_obj_eq(strContainer.getValue(), "World")
+}
+
+type GenericMath<T> = impl (
+    value1: T,
+    value2: T
+) {
+    fn addValues() -> T {
+        return this.value1 + this.value2
+    }
+}
+
+type MathOperation<T> = class {
+    let value1: T
+    let value2: T
+
+    impl GenericMath<T>(value1, value2)
+
+    fn init(mut value1: T, mut value2: T) {
+        this.value1 = value1
+        this.value2 = value2
+    }
+}
+
+fn test_generic_math(rn: TestUnit) {
+    let op = new MathOperation<Vec3>(new Vec3(1.0f, 2.0f, 3.0f), new Vec3(4.0f, 5.0f, 6.0f))
+    let result = op.addValues()
+    rn.assert_obj_eq(result, new Vec3(5.0f, 7.0f, 9.0f))
+}
+
+fn test_static_mesh(rn: TestUnit) {
+    let pos = new Vec3(1.0f, 2.0f, 3.0f)
+    let rot = new Vec3(4.0f, 5.0f, 6.0f)
+    let scale = new Vec3(7.0f, 8.0f, 9.0f)
+
+    let mesh = new StaticMesh(pos, rot, scale)
+    rn.assert_obj_eq(mesh.getPosition(), pos)
+    rn.assert_obj_eq(mesh.getRotation(), rot)
+    rn.assert_obj_eq(mesh.getScale(), scale)
+
+    let mesh2 = new StaticMesh(new Vec3(5.0f, 10.0f, -10.0f), new Vec3(4.0f, 5.0f, 6.0f), new Vec3(7.0f, 8.0f, 9.0f))
+    mesh.obj_parent = mesh2
+
+    let worldPos = mesh.getWorldPosition()
+    let expectedWorldPos = new Vec3(6.0f, 12.0f, -7.0f)
+    rn.assert_obj_eq(worldPos, expectedWorldPos)
+}
+
+fn main() -> u32 {
+    let test_1 = new TestUnit("test callable placeholder", "Tests callable behavior with generics", test_callable_placeholder)
+    let test_2 = new TestUnit("test static mesh", "Tests composable 3D object properties", test_static_mesh)
+    let test_3 = new TestUnit("test generic container", "Tests generic implementation with set and get", test_generic_container)
+    let test_4 = new TestUnit("test generic math", "Tests generic implementation with math operations", test_generic_math)
+
+    let set = new UnitSet("Impl Feature Test Suite", "Tests implementation of composable behaviors using impl", [test_1, test_2, test_3, test_4])
+
+    return set.run()
+}


### PR DESCRIPTION
This PR adds `impl` support for Type-C.

(the following is from unpublished docs)


# Implementations

Implementation types exhibit a very similar behavior to traits. They provide chunks of methods that a class can reuse.

An implementation models the following properties:

- The required attributes the class must have
- The required interface the class must implement
- The methods that the class will have once the implementation is applied

```tc
type Vec3 = class {
    let x: f32, y: f32, z: f32

    fn init(x: f32, y: f32, z: f32) {
        this += {x, y, z}
    }

    fn init(){
        this.x = this.y = this.z = 0.0f
    }

    fn add | + (v: Vec3) -> Vec3 {
        return new Vec3(this.x + v.x, this.y + v.y, this.z + v.z)
    }
}

type Object3D = interface {

    // XYZ API
    fn getRotation() -> Vec3
    fn setRotation(mut rot: Vec3) -> void
    fn getPosition() -> Vec3
    fn setPosition(pos: Vec3) -> void
    fn getScale() -> Vec3
    fn setScale(scale: Vec3) -> void
    fn translate(translation: Vec3) -> void
    fn lookAt(target: Vec3) -> void

    // World API
    fn getWorldPosition() -> Vec3
    fn getWorldRotation() -> Vec3
    fn getWorldScale() -> Vec3


    // Parent API
    fn addChild(child: Object3D) -> void
    fn removeChild(child: Object3D) -> void
    fn getParent() -> Object3D?
    fn getChildren() -> Object3D[]


    // Renderer API
    fn render() -> void

    // Updater API
    fn update(dt: f32) -> void
}
```

In this, any class that implements the `Object3D` interface must implement a lot of methods, which is
very reptitive if a lot of classes exhibit the same behavior. This is where implementations come in.

One can refactor this into an ECS-like system, or, use implementations to reduce the amount of code needed.

```tc
type Default3DPropsAccessTrait = impl (
    position: Vec3,
    rotation: Vec3,
    scale: Vec3
) {
    fn getRotation() -> Vec3 = this.rotation
    fn getPosition() -> Vec3 = this.position
    fn getScale() -> Vec3 = this.scale

    fn setRotation(mut rot: Vec3) -> void {
        this.rotation = rot
    }

    fn setPosition(pos: Vec3) -> void {
        this.position = pos
    }

    fn setScale(scale: Vec3) -> void {
        this.scale = scale
    }
}
```

In this example, we have created an implemtation, where the class must have the `position`, `rotation`, and `scale` attributes,
and the `Object3D` interface.

```tc
type StaticMesh = class {
    let position: Vec3, rotation: Vec3, scale: Vec3
    let mesh: Mesh

    impl Default3DPropsAccessTrait(position, rotation, scale)

    fn init(mesh: Mesh, position: Vec3, rotation: Vec3, scale: Vec3) {
        this += {position, rotation, scale, mesh}
    }

    fn render() -> void {
        // Render the mesh
    }
}
```

The Implementation `Default3DPropsAccessTrait` essentially provides parameterized methods that the class can use.
The parameters are the attributes required by the implementation, which can be passed in the `impl` statement within the class

Now let's see how we can create an implementation for world attributes:

```tc
type DefaultWorldTrait = impl for interface {
    fn getPosition() -> Vec3
    fn getRotation() -> Vec3
    fn getScale() -> Vec3
} (
    parent: Object3D?
) {
    fn getWorldPosition() -> Vec3 {
        if(this.parent == null){
            return this.getPosition()
        }
        this.getPosition() * this.parent.getWorldPosition()
    }

    fn getWorldRotation() -> Vec3 {
        if(parent == null){
            return this.getRotation()
        }
        return this.getRotation() + parent.getWorldRotation()
    }

    fn getWorldScale() -> Vec3 {
        if(this.parent == null){
            return this.getScale()
        }
        return this.getScale() * this.parent.getWorldScale()
    }
}
```
